### PR TITLE
Update build process for better data compression

### DIFF
--- a/PWFSLSmoke.Rproj
+++ b/PWFSLSmoke.Rproj
@@ -18,5 +18,6 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageBuildArgs: --resave-data
 PackageCheckArgs: --ignore-vignettes
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Adding the argument `--resave-data` to the `R CMD build` command reduces the file size of the data included in the package. Also, it removes the last warning from the `R CMD check` process (seeing all green checks are nice).

_The version number has not been updated, as this doesn't alter package functionality._