### PR TITLE
Enhance getcurrentstatus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,13 @@ vignettes/*.pdf
 *.utf8.md
 *.knit.md
 
+# Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
+rsconnect/
+.Rproj.user
+
 ################################################################################
 # Additional Mazama Science items
 
 # OS X stuff
 .DS_Store
 
-.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Type: Package
 Package: PWFSLSmoke
-Version: 1.1.18
+Version: 1.1.19
 Title: Utilities for Working with Air Quality Monitoring Data
 Authors@R: c(
     person("Jonathan", "Callahan", email="jonathan.s.callahan@gmail.com", role=c("aut","cre")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# PWFSLSmoke 1.1.19
+
+This release enhances `monitor_getCurrentStatus()`.
+
+ * Added 'summary' columns for previous times to match last times
+ * Renamed `yesterdayAQI` column to `yesterday_pm25_24hr` for better fit with
+   the column naming scheme
+ * Added `last_validLocalTimestamp` and `previous_validLocalTimestamp` columns,
+   which are strings showing the local time at a monitor
+
 # PWFSLSmoke 1.1.18
 
 This release refactors functions prefixed with `monitorPlot_*` to instead start

--- a/R/monitor_getCurrentStatus.R
+++ b/R/monitor_getCurrentStatus.R
@@ -51,6 +51,10 @@
 #'   last_PM2.5_1hr        \tab Last valid raw PM2.5 measurement\cr
 #'   last_PM2.5_3hr        \tab Mean of the last valid raw PM2.5 measurement
 #'                              with the preceding two measurements\cr
+#'   previous_nowcast_1hr  \tab Previous valid NowCast measurement\cr
+#'   previous_PM2.5_1hr    \tab Previous valid raw PM2.5 measurement\cr
+#'   previous_PM2.5_3hr    \tab Mean of the previous valid raw PM2.5 measurement
+#'                              with the preceding two measurements\cr
 #'   last_nowcastLevel     \tab NowCast level at the last valid time\cr
 #'   previous_nowcastLevel \tab NowCast level at the previous valid time
 #' }
@@ -179,6 +183,9 @@ monitor_getCurrentStatus <- function(ws_monitor,
       .averagePrior(nowcast_data, lastValidTimeIndex, 1, "last_nowcast_1hr"),
       .averagePrior(ws_data, lastValidTimeIndex, 1, "last_pm25_1hr"),
       .averagePrior(ws_data, lastValidTimeIndex, 3, "last_pm25_3hr"),
+      .averagePrior(nowcast_data, previousValidTimeIndex, 1, "previous_nowcast_1hr"),
+      .averagePrior(ws_data, previousValidTimeIndex, 1, "previous_pm25_1hr"),
+      .averagePrior(ws_data, previousValidTimeIndex, 3, "previous_pm25_3hr"),
       .aqiLevel(nowcast_data, lastValidTimeIndex, "last_nowcastLevel"),
       .aqiLevel(nowcast_data, previousValidTimeIndex, "previous_nowcastLevel")
     ) %>%

--- a/R/monitor_getCurrentStatus.R
+++ b/R/monitor_getCurrentStatus.R
@@ -128,6 +128,8 @@ monitor_getCurrentStatus <- function(ws_monitor,
 
 # Prepare data ------------------------------------------------------------
 
+  processingTime <- lubridate::now("UTC")
+
   ws_data <- ws_monitor %>% monitor_extractData() %>% as_tibble()
   ws_meta <- ws_monitor %>% monitor_extractMeta() %>% as_tibble(rownames = NULL)
 
@@ -143,34 +145,62 @@ monitor_getCurrentStatus <- function(ws_monitor,
   #  how are different timezones handled when compared against endTime
   #  and processingTime?
 
-  processingTime <- lubridate::now("UTC")
+  ## NOTE:
+  #  The number of levels of valid time indices is set by `indexLevels`, with
+  #  lower numbers corresponding to more recent times.
+
+  indexLevels <- 1:2
 
   validTimeIndices <- ws_data %>%
     arrange(.data$datetime) %>%
     select(-.data$datetime) %>%
-    purrr::map(~rev(which(!is.na(.x)))[1:2]) %>%
-    purrr::transpose()
+    purrr::map(~rev(which(!is.na(.x)))[indexLevels]) %>%
+    tibble::enframe("monitorID", "index") %>%
+    tidyr::unnest(.data$index) %>%
+    group_by(.data$monitorID) %>%
+    mutate(key = row_number()) %>%
+    tidyr::spread(.data$key, .data$index)
 
-  lastValidTimeIndex <- unlist(validTimeIndices[[1]])
-  previousValidTimeIndex <- unlist(validTimeIndices[[2]])
+  ## NOTE:
+  #  The last and previous valid time indices are created as named vectors for
+  #  easy portability to helper functions later on.
 
-  lastValidTime <- ws_data[["datetime"]][lastValidTimeIndex]
-  previousValidTime <- ws_data[["datetime"]][previousValidTimeIndex]
+  lastValidTimeIndex <- validTimeIndices %>%
+    select(.data$monitorID, .data$`1`) %>%
+    tibble::deframe()
+  previousValidTimeIndex <- validTimeIndices %>%
+    select(.data$monitorID, .data$`2`) %>%
+    tibble::deframe()
+
+  latencyStatus <-
+    validTimeIndices %>%
+    mutate(
+      `last_validTime` = ws_data[["datetime"]][.data$`1`],
+      `last_latency` = difftime(endTimeInclusive, .data$last_validTime, units = "hour"),
+      `previous_validTime` = ws_data[["datetime"]][.data$`2`],
+      `previous_latency` = difftime(.data$last_validTime, .data$previous_validTime,  units = "hour")
+    ) %>%
+    select(-.data$`1`, -.data$`2`)
 
 
 # Initialize output -------------------------------------------------------
 
   currentStatus <-
-    tibble(
-      `monitorID` = names(lastValidTimeIndex),
+    ws_meta %>%
+    mutate(
       `monitorURL` = paste0(monitorURLBase, .data$monitorID),
       `processingTime` = processingTime,
-      `endTime` = endTime,
-      `last_validTime` = lastValidTime,
-      `last_latency` = difftime(endTimeInclusive, lastValidTime, units = "hour"),
-      `previous_validTime` = previousValidTime,
-      `previous_latency` = difftime(.data$last_validTime, .data$previous_validTime,  units = "hour")
-  )
+      `endTime` = endTime
+    ) %>%
+    left_join(latencyStatus, by = "monitorID") %>%
+    mutate(
+      `last_validLocalTimestamp` =
+        lubridate::with_tz(.data$last_validTime, tzone = .data$timezone) %>%
+        strftime(format = "%Y-%m-%d %H:%M:%S %Z"),
+      `previous_validLocalTimestamp` =
+        lubridate::with_tz(.data$previous_validTime, tzone = .data$timezone) %>%
+        strftime(format = "%Y-%m-%d %H:%M:%S %Z")
+    )
 
 
 # Add summary data --------------------------------------------------------
@@ -215,10 +245,7 @@ monitor_getCurrentStatus <- function(ws_monitor,
 
 # Return output -----------------------------------------------------------
 
-  ## TODO: Add option to not append meta info?
-
-  outputData <- left_join(ws_meta, eventData, by = "monitorID")
-  return(outputData)
+  return(eventData)
 
 }
 

--- a/R/monitor_getCurrentStatus.R
+++ b/R/monitor_getCurrentStatus.R
@@ -45,7 +45,7 @@
 #' summaries included are listed below with a description:
 #'
 #' \tabular{ll}{
-#'   yesterday_AQI         \tab Daily AQI value for the day prior to
+#'   yesterday_pm25_24hr   \tab Daily AQI value for the day prior to
 #'                              \code{endTime}\cr
 #'   last_nowcast_1hr      \tab Last valid NowCast measurement\cr
 #'   last_PM2.5_1hr        \tab Last valid raw PM2.5 measurement\cr
@@ -175,7 +175,7 @@ monitor_getCurrentStatus <- function(ws_monitor,
 
   summaryData <-
     list(
-      .yesterday_AQI(ws_monitor, endTime, "yesterday_AQI"),
+      .yesterday_avg(ws_monitor, endTime, "yesterday_pm25_24hr"),
       .averagePrior(nowcast_data, lastValidTimeIndex, 1, "last_nowcast_1hr"),
       .averagePrior(ws_data, lastValidTimeIndex, 1, "last_pm25_1hr"),
       .averagePrior(ws_data, lastValidTimeIndex, 3, "last_pm25_3hr"),
@@ -310,7 +310,7 @@ if (FALSE) {
 #'   before \code{endTimeUTC}.
 #'
 #' @noRd
-.yesterday_AQI <- function(ws_monitor, endTimeUTC, colTitle) {
+.yesterday_avg <- function(ws_monitor, endTimeUTC, colTitle) {
 
   get_previousDayStart <- function(endTimeUTC, timezone) {
 
@@ -323,7 +323,7 @@ if (FALSE) {
 
   }
 
-  get_previousDayAQI <- function(ws_data, previousDayStart) {
+  get_previousDayAvg <- function(ws_data, previousDayStart) {
 
     # See NOTE on tidy evaluation for explanation of `!!` and `enquo()`
 
@@ -361,7 +361,7 @@ if (FALSE) {
   previousDayAQI <-
     purrr::map2_dfc(
       aqiDataList, previousDayStarts,
-      ~get_previousDayAQI(.x, .y)
+      ~get_previousDayAvg(.x, .y)
     ) %>%
     tidyr::gather("monitorID", !!colTitle)
 

--- a/localExamples/PortlandSmokeMtg_2017.R
+++ b/localExamples/PortlandSmokeMtg_2017.R
@@ -3,15 +3,16 @@ library(PWFSLSmoke)
 
 # Washington, Oregon August 22, 2015 ------------------------------------------
 
-pnw <- airnow_load(20150731, 20150901, stateCodes=c('or','wa'))
+pnw <- monitor_loadAnnual(2015) %>%
+  monitor_subset(stateCodes=c('or','wa'), tlim=c(20150731,20150901))
 
 # Timeseries overview
 monitor_timeseriesPlot(pnw, style='gnats')
 
 # Oklahoma recent -------------------------------------------------------------
 
-latest <- airnow_loadLatest()
-ok <- monitor_subset(latest, stateCodes='OK')
-monitor_map(ok)
+monitor_loadLatest() %>%
+  monitor_subset(stateCodes='OK') %>%
+  monitor_map()
 
 

--- a/localExamples/Washington_August_2015.R
+++ b/localExamples/Washington_August_2015.R
@@ -87,7 +87,7 @@ title('Terrible Smoke in late August')
 merged_worst_24hr <- monitor_rollingMean(merged_worst, width=24, align="right")
 
 # Plot map and timeseries
-monitord_dygraph(merged_worst_24hr, title='24 Hour Average PM2.5')
+monitor_dygraph(merged_worst_24hr, title='24 Hour Average PM2.5')
 
 # In the second half of August, how many hours per day was the air unhealthy?
 late_august <- monitor_subset(merged_worst, tlim=c(20150816,20150831))

--- a/man/monitor_getCurrentStatus.Rd
+++ b/man/monitor_getCurrentStatus.Rd
@@ -64,11 +64,15 @@ information for the data part of the given \emph{ws_monitor} object. The
 summaries included are listed below with a description:
 
 \tabular{ll}{
-  yesterday_AQI         \tab Daily AQI value for the day prior to
+  yesterday_pm25_24hr   \tab Daily AQI value for the day prior to
                              \code{endTime}\cr
   last_nowcast_1hr      \tab Last valid NowCast measurement\cr
   last_PM2.5_1hr        \tab Last valid raw PM2.5 measurement\cr
   last_PM2.5_3hr        \tab Mean of the last valid raw PM2.5 measurement
+                             with the preceding two measurements\cr
+  previous_nowcast_1hr  \tab Previous valid NowCast measurement\cr
+  previous_PM2.5_1hr    \tab Previous valid raw PM2.5 measurement\cr
+  previous_PM2.5_3hr    \tab Mean of the previous valid raw PM2.5 measurement
                              with the preceding two measurements\cr
   last_nowcastLevel     \tab NowCast level at the last valid time\cr
   previous_nowcastLevel \tab NowCast level at the previous valid time

--- a/man/tidy_toMonitor.Rd
+++ b/man/tidy_toMonitor.Rd
@@ -14,7 +14,7 @@ tidy_toMonitor(data = NULL)
 }
 \description{
 Changes read-optomized 'tidy' formatted monitor data into a write-optomized
-`ws_monitor` format. If the given data is already a `ws_monitor` object, 
+`ws_monitor` format. If the given data is already a `ws_monitor` object,
 it is returned as is. This function is the inverse of \code{\link{monitor_toTidy}}.
 }
 \examples{


### PR DESCRIPTION
Enhancements to `monitor_getCurrentStatus()`

 * Added 'summary' columns for previous times to match last times
 * Renamed `yesterdayAQI` column to `yesterday_pm25_24hr` for better fit with
   the column naming scheme
 * Added `last_validLocalTimestamp` and `previous_validLocalTimestamp` columns,
   which are strings showing the local time at a monitor

closes #53 